### PR TITLE
Added DeepSpeed Implementation Example for PaLM-pytorch

### DIFF
--- a/examples/enwik8_deepspeed/README.md
+++ b/examples/enwik8_deepspeed/README.md
@@ -1,0 +1,12 @@
+
+# PaLM-pytorch with Deepspeed for Enwik8
+
+Deepspeed is the framework Microsoft used to train the world's largest Attention model (17GB) to date. They have open sourced it, and it works with PaLM Pytorch!
+
+1. First install Deepspeed following instructions from their official repository https://github.com/microsoft/DeepSpeed
+
+2. Run the following command in this folder
+
+```bash
+$ deepspeed train.py --deepspeed --deepspeed_config ds_config.json
+```

--- a/examples/enwik8_deepspeed/ds_config.json
+++ b/examples/enwik8_deepspeed/ds_config.json
@@ -1,0 +1,35 @@
+{
+    "train_batch_size": 32,
+    "gradient_accumulation_steps": 4,
+    "steps_per_print": 2000,
+    "max_grad_norm": 0.5,
+    "optimizer": {
+      "type": "Adam",
+      "params": {
+        "lr": 0.0002,
+        "betas": [
+          0.8,
+          0.999
+        ],
+        "eps": 1e-8
+      }
+    },
+    "fp16": {
+      "enabled": true,
+      "loss_scale": 0,
+      "loss_scale_window": 1000,
+      "hysteresis": 2,
+      "min_loss_scale": 1
+    },
+    "scheduler": {
+      "type": "WarmupLR",
+      "params": {
+        "warmup_min_lr": 0,
+        "warmup_max_lr": 0.0002,
+        "warmup_num_steps": 1000
+      }
+    },
+    "zero_optimization": true,
+    "wall_clock_breakdown": false
+  }
+  

--- a/examples/enwik8_deepspeed/train.py
+++ b/examples/enwik8_deepspeed/train.py
@@ -1,0 +1,115 @@
+import deepspeed
+
+from palm_pytorch import PaLM
+from palm_pytorch.autoregressive_wrapper import AutoregressiveWrapper
+
+import random
+import tqdm
+import gzip
+import numpy as np
+import torch
+import torch.optim as optim
+from einops import rearrange
+from torch import einsum, nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset
+
+def add_argument():
+    parser=argparse.ArgumentParser(description='enwik8')
+
+    parser.add_argument('--with_cuda', default=False, action='store_true',
+                        help='use CPU in case there\'s no GPU support')
+    parser.add_argument('--use_ema', default=False, action='store_true',
+                        help='whether use exponential moving average')
+    parser.add_argument('-b', '--batch_size', default=32, type=int,
+                        help='mini-batch size (default: 32)')
+    parser.add_argument('-e', '--epochs', default=30, type=int,
+                        help='number of total epochs (default: 30)')
+    parser.add_argument('--local_rank', type=int, default=-1,
+                       help='local rank passed from distributed launcher')
+
+    parser = deepspeed.add_config_arguments(parser)
+    args=parser.parse_args()
+    return args
+
+# constants
+
+EPOCHS = 20
+GRADIENT_ACCUMULATE_EVERY = 4
+VALIDATE_EVERY = 100
+GENERATE_EVERY = 500
+GENERATE_LENGTH = 512
+SEQ_LEN = 1024
+
+# helpers
+
+def decode_token(token):
+    return str(chr(max(32, token)))
+
+def decode_tokens(tokens):
+    return "".join(list(map(decode_token, tokens)))
+
+# instantiate GPT-like decoder model
+
+model = PaLM(num_tokens = 256, dim = 512, depth = 8)
+
+model = AutoregressiveWrapper(model, max_seq_len=2048)
+model.cuda()
+
+# prepare enwik8 data
+
+with gzip.open('./data/enwik8.gz') as file:
+    X = np.fromstring(file.read(int(95e6)), dtype=np.uint8)
+    trX, vaX = np.split(X, [int(90e6)])
+    data_train, data_val = torch.from_numpy(trX), torch.from_numpy(vaX)
+
+class TextSamplerDataset(Dataset):
+    def __init__(self, data, seq_len):
+        super().__init__()
+        self.data = data
+        self.seq_len = seq_len
+
+    def __getitem__(self, index):
+        rand_start = torch.randint(0, self.data.size(0) - self.seq_len, (1,))
+        full_seq = self.data[rand_start : rand_start + self.seq_len + 1].long()
+        return full_seq
+
+    def __len__(self):
+        return self.data.size(0) // self.seq_len
+
+train_dataset = TextSamplerDataset(data_train, SEQ_LEN)
+val_dataset = TextSamplerDataset(data_val, SEQ_LEN)
+
+# setup deepspeed
+
+cmd_args = add_argument()
+model_engine, optimizer, trainloader, _ = deepspeed.initialize(args=cmd_args, model=model, model_parameters=model.parameters(), training_data=train_dataset)
+
+# training
+
+for _ in range(EPOCHS):
+    for i, data in enumerate(trainloader):
+        model_engine.train()
+        data = data.to(model_engine.local_rank)
+        loss = model_engine(data)
+        model_engine.backward(loss)
+        torch.nn.utils.clip_grad_norm_(model_engine.parameters(), 0.5)
+        model_engine.step()
+        print(loss.item() * GRADIENT_ACCUMULATE_EVERY)
+
+        if i % VALIDATE_EVERY == 0:
+            model.eval()
+            with torch.no_grad():
+                inp = random.choice(val_dataset)[:-1]
+                loss = model(inp[None, :].cuda())
+                print(f'validation loss: {loss.item()}')
+
+        if i % GENERATE_EVERY == 0:
+            model.eval()
+            inp = random.choice(val_dataset)[:-1]
+            prime = decode_tokens(inp)
+            print(f'%s \n\n %s', (prime, '*' * 100))
+
+            sample = model.generate(inp[None, ...].cuda(), GENERATE_LENGTH)
+            output_str = decode_tokens(sample[0])
+            print(output_str)


### PR DESCRIPTION
Implementation of PaLM-pytorch with Microsoft's DeepSpeed. Tested locally with both CLI and JupyterNotebook. Please double check to ensure that the DeepSpeed implementation meets your current standards and the PaLM model is fully/properly implemented as should be, per your previous specifications in repositories such as Reformer Pytorch. Specifically, the correct placement of: `torch.nn.utils.clip_grad_norm_(model_engine.parameters(), 0.5)` in the training loop.

Sidenote, GitHub is not allowing me to upload the enwik8.gz file to the data folder.

I greatly appreciate your contributions to the open-source community. 

Thank you.